### PR TITLE
Load credentials.json

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,6 +6,11 @@ catch (FileNotFoundException fnf) {
     mapProperties['google_maps_api_key']='MISSING'
 }
 
+try { mapProperties['google_creds'] = new File('credentials.json').text }
+catch(FileNotFoundException fnf) {
+    mapProperties['google_creds']='MISSING'
+}
+
 android {
     compileSdkVersion 31
     defaultConfig {
@@ -15,7 +20,7 @@ android {
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-        manifestPlaceholders = [mapApiKey:mapProperties['google_maps_api_key']]
+        manifestPlaceholders = [mapApiKey:mapProperties['google_maps_api_key'], googleCreds:mapProperties['google_creds']]
     }
     buildTypes {
         release {
@@ -46,11 +51,11 @@ dependencies {
     implementation 'io.objectbox:objectbox-android:2.9.1'
     implementation 'org.shredzone.commons:commons-suncalc:3.5'
     implementation 'org.locationtech.proj4j:proj4j:1.1.4'
+    testImplementation 'org.json:json:20211205'
+    testImplementation 'junit:junit:4.13.2'
     testImplementation 'com.google.api-client:google-api-client:1.33.0'
     testImplementation 'com.google.oauth-client:google-oauth-client-jetty:1.32.1'
     testImplementation 'com.google.apis:google-api-services-sheets:v4-rev20210629-1.32.1'
-    testImplementation 'org.json:json:20211205'
-    testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
     androidTestImplementation 'androidx.test:runner:1.4.0'

--- a/app/src/androidTest/java/com/example/clicker/AppContextTest.java
+++ b/app/src/androidTest/java/com/example/clicker/AppContextTest.java
@@ -1,8 +1,12 @@
 package com.example.clicker;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 
 import android.content.Context;
+import android.content.pm.PackageManager;
+import android.os.Bundle;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.platform.app.InstrumentationRegistry;
@@ -21,7 +25,15 @@ public class AppContextTest {
     public void useAppContext() {
         // Context of the app under test.
         Context appContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
-
         assertEquals("com.example.clicker", appContext.getPackageName());
+    }
+
+    @Test
+    public void checkMetaDataAvailable() throws PackageManager.NameNotFoundException {
+        Context appContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        Bundle metaData = appContext.getPackageManager().getApplicationInfo(appContext.getPackageName(), PackageManager.GET_META_DATA).metaData;
+        assertNotNull(metaData);
+        assertNotEquals("MISSING", metaData.getString("com.google.android.maps.v2.API_KEY"));
+        assertNotEquals("MISSING", metaData.getString("com.google.api.credentials"));
     }
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,6 +23,9 @@
         <meta-data
             android:name="com.google.android.maps.v2.API_KEY"
             android:value="${mapApiKey}" />
+        <meta-data
+            android:name="com.google.api.credentials"
+            android:value="${googleCreds}"/>
         <activity
             android:name="com.example.clicker.SettingsActivity"
             android:label="@string/title_activity_settings"/>

--- a/app/src/test/java/com/example/clicker/SheetsTest.java
+++ b/app/src/test/java/com/example/clicker/SheetsTest.java
@@ -17,7 +17,6 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.GeneralSecurityException;
@@ -42,7 +41,7 @@ public class SheetsTest {
     public void setUp() throws Exception {
         final NetHttpTransport HTTP_TRANSPORT = GoogleNetHttpTransport.newTrustedTransport();
 
-        try ( InputStream in = new FileInputStream(new File(CREDENTIALS_FILE_PATH)) ) {
+        try (InputStream in = new FileInputStream(new File(CREDENTIALS_FILE_PATH))) {
             GoogleCredential credentials = GoogleCredential.fromStream(in).createScoped(SCOPES);
             service = new Sheets.Builder(HTTP_TRANSPORT, JSON_FACTORY, credentials)
                     .setApplicationName(APPLICATION_NAME)


### PR DESCRIPTION
 Added credendials.json to be loaded into manifest and a test case as an example on how to retrieve it.  There seems to be an issue with the google dependencies, when they are not used as tests, but merged into the android app we get a duplicate META-INF error.  Not sure whats up with that.