### PR TITLE
Fix for Android 11+

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,7 +20,7 @@ android {
     defaultConfig {
         applicationId "com.example.clicker"
         minSdkVersion 26
-        targetSdkVersion 31
+        targetSdkVersion 29 // LEAVE THIS AT 29 UNTIL WE FIGURE OUT HOW TO READ MBTILES ON ANDROID 11+
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
Android 11 and up changed how files are accessed, until we change how we are reading mbtiles file, target Android v10.