### PR TITLE
Startup crashing bug

### DIFF
--- a/app/src/main/java/com/example/clicker/ObjectBoxApp.java
+++ b/app/src/main/java/com/example/clicker/ObjectBoxApp.java
@@ -1,7 +1,13 @@
 package com.example.clicker;
 
+import static android.Manifest.permission.BLUETOOTH_CONNECT;
+
+import android.Manifest;
+import android.app.Activity;
 import android.app.Application;
 import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.os.Build;
 import android.os.Handler;
 import android.util.Log;
 
@@ -38,7 +44,10 @@ public class ObjectBoxApp extends Application {
 
         // Initialize the Flic2 manager to run on the same thread as the current thread (the main thread)
         Flic2Manager manager = Flic2Manager.initAndGetInstance(getApplicationContext(), new Handler());
-        registerClickerButtons(manager);
+
+        // Make sure we can connect to BlueTooth Buttons
+        if (permissionsPresentToConnectButtons())
+            registerClickerButtons(manager);
     }
 
     private void registerClickerButtons(Flic2Manager manager) {
@@ -50,6 +59,22 @@ public class ObjectBoxApp extends Application {
         }
     }
 
+    private boolean permissionsPresentToConnectButtons() {
+        boolean retVal = true;
+        if (Build.VERSION.SDK_INT < 31 || getApplicationInfo().targetSdkVersion < 31) {
+            if (checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
+                Log.d(TAG, "Application startup and we do not have ACCESS_FINE_LOCATION permission.  Not connecting to buttons.");
+                retVal = false;
+            }
+        } else {
+            if (checkSelfPermission(Manifest.permission.BLUETOOTH_SCAN) != PackageManager.PERMISSION_GRANTED ||
+                    checkSelfPermission(Manifest.permission.BLUETOOTH_CONNECT) != PackageManager.PERMISSION_GRANTED) {
+                Log.d(TAG, "Application startup and we do not have BLUETOOTH_SCAN or BLUETOOTH_CONNECT permissions.  Not connecting to buttons.");
+                retVal = false;
+            }
+        }
+        return retVal;
+    }
     public BoxStore getBoxStore() {
         return boxStore;
     }

--- a/app/src/main/java/com/example/clicker/SettingsFragment.java
+++ b/app/src/main/java/com/example/clicker/SettingsFragment.java
@@ -104,7 +104,7 @@ public class SettingsFragment extends PreferenceFragmentCompat {
                     isScanning = false;
 
                     if (result == Flic2ScanCallback.RESULT_SUCCESS) {
-                        Toast.makeText(getActivity(), "Scan success!", Toast.LENGTH_LONG).show();
+                        Toast.makeText(getActivity(), "Scan success!  You will need to stop and restart the application.", Toast.LENGTH_LONG).show();
                     } else {
                         Toast.makeText(getActivity(), "Scan failed with code " + Flic2Manager.errorCodeToString(result), Toast.LENGTH_LONG).show();
                     }


### PR DESCRIPTION
 Fixed up startup app so if permissions are not present for buttons, application will still startup.  When a new install on a new phone happens, the permissions are not granted, but we are attempting to connect to any buttons that have been recognized.  Just check for permissions existing before attempting to connect, if the permissions don't exist, just log the fact and continue to start up.  

This is probably only a problem when moving to a new phone and restoring a backup.  In that case, all the saved BT connections/buttons are there, but the application doesn't have permissions granted yet on first startup.  This patch fixes this.